### PR TITLE
Pacakage tasks detects GitHub Actions Environment

### DIFF
--- a/build/PackageTask.cs
+++ b/build/PackageTask.cs
@@ -1,4 +1,6 @@
 
+using Cake.Common.Build;
+
 namespace BuildScripts;
 
 [TaskName("Package")]
@@ -11,8 +13,16 @@ public sealed class PackageTask : FrostingTask<BuildContext>
         var patch = context.FindRegexMatchGroupInFile("freetype/include/freetype/freetype.h", @"#define FREETYPE_PATCH +(?<ver>\d+)", 1, System.Text.RegularExpressions.RegexOptions.Singleline);
         var version = $"{major}.{minor}.{patch}";
         var dnMsBuildSettings = new DotNetMSBuildSettings();
-        dnMsBuildSettings.WithProperty("Version", version + "." + context.EnvironmentVariable("GITHUB_RUN_NUMBER"));
-        dnMsBuildSettings.WithProperty("RepositoryUrl", "https://github.com/" + context.EnvironmentVariable("GITHUB_REPOSITORY"));
+
+        if (context.BuildSystem().IsRunningOnGitHubActions)
+        {
+            dnMsBuildSettings.WithProperty("Version", version + "." + context.EnvironmentVariable("GITHUB_RUN_NUMBER"));
+            dnMsBuildSettings.WithProperty("RepositoryUrl", "https://github.com/" + context.EnvironmentVariable("GITHUB_REPOSITORY"));
+        }
+        else
+        {
+            dnMsBuildSettings.WithProperty("Version", version);
+        }
 
         context.DotNetPack("src/MonoGame.Library.FreeType.csproj", new DotNetPackSettings
         {


### PR DESCRIPTION
Updates the Package build task to detect if is running in a GitHub Acitons environment.  This resolves an issue when trying to run it locally and the `GITHUB_RUN_NUMBER` environment variable being unavailable which throws an error due to an invalid version number scheme.